### PR TITLE
Minor update to plugin.xml to avoid conflict issues when using edit-config in config.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -49,7 +49,7 @@
                 <param name="android-package" value="com.appsflyer.cordova.plugin.AppsFlyerPlugin"/>
             </feature>
         </config-file>
-        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest" mode="merge">
+        <config-file target="AndroidManifest.xml" parent="/manifest" mode="merge">
             <uses-permission android:name="android.permission.INTERNET"/>
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -53,7 +53,7 @@
             <uses-permission android:name="android.permission.INTERNET"/>
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
         </config-file>
-        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest/application" mode="merge">
+        <config-file target="AndroidManifest.xml" parent="/*/application">
             <receiver android:name="com.appsflyer.MultipleInstallBroadcastReceiver" android:exported="true">
                 <intent-filter>
                     <action android:name="com.android.vending.INSTALL_REFERRER" />


### PR DESCRIPTION
Minor change to plugin.xml to avoid conflict issue when using edit-config in config.xml. 
If we use the edit-config tag in our config.xml, we would get a "Conflict found, edit-config changes from config.xml will overwrite plugin.xml changes" error and this minor change will fix that.