### PR TITLE
v6 Breaking Changes' letter case correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We have renamed the following APIs:
 | Old API | New API |
 |---------|---------|
 |trackEvent      |  logEvent|
-|stopTracking      |  stop|
+|stopTracking      |  Stop|
 |trackCrossPromotionImpression |  logCrossPromotionImpression|
 |trackAndOpenStore      |  logCrossPromotionAndOpenStore|
 |setDeviceTrackingDisabled      |  anonymizeUser|


### PR DESCRIPTION
v6 Breaking Changes' letter case correction of the method `Stop`.