### PR TITLE
add appsFlyer dev key in the AppDelegeate.m

### DIFF
--- a/docs/Guides.md
+++ b/docs/Guides.md
@@ -251,6 +251,7 @@ For plugin version **6.2.0** and up you need to add this to `didFinishLaunchingW
     [[AppsFlyerLib shared] setDelegate:_AppsFlyerdelegate]; //if you want to use onAppOpenAttribution listener (registerOnAppOpenAttribution())
     //OR
     [[AppsFlyerLib shared] setDeepLinkDelegate:_AppsFlyerdelegate]; //if you want to use DDL listener (registerDeepLink())
+    [AppsFlyerLib shared].appsFlyerDevKey = @"devkey"; // replace APPSFLYER_DEV_KEY with your dev key
 ```
 And `#import "AppsFlyerPlugin.h"` to `AppDelegate.m` 
 


### PR DESCRIPTION
This line solves the issue of opening a short link when the app is not in the background to start an in-app activity