### PR TITLE
fix: import NonNull error

### DIFF
--- a/src/android/com/appsflyer/cordova/plugin/AppsFlyerPlugin.java
+++ b/src/android/com/appsflyer/cordova/plugin/AppsFlyerPlugin.java
@@ -34,7 +34,7 @@ import com.appsflyer.AppsFlyerInAppPurchaseValidatorListener;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import static com.appsflyer.cordova.plugin.AppsFlyerConstants.*;


### PR DESCRIPTION
This is based on this error https://github.com/AppsFlyerSDK/appsflyer-cordova-plugin/issues/153.

The reason we need this fix as part of the lib is that we use Capacitor and we automatically sync our projects which removes any manual changes.

Probably `master` is not the right target, please advice about the change and branch