### PR TITLE
Add new required permission

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -51,6 +51,7 @@
             <uses-permission android:name="android.permission.INTERNET"/>
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
             <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+            <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*/application">
             <receiver android:name="com.appsflyer.MultipleInstallBroadcastReceiver" android:exported="true">


### PR DESCRIPTION
Permission  required for Android apps with API level set to 31 (Android 12) or later.
https://support.google.com/googleplay/android-developer/answer/6048248