### PR TITLE
Fix issue with cordova-commons

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -47,7 +47,7 @@
                 <param name="android-package" value="com.appsflyer.cordova.plugin.AppsFlyerPlugin"/>
             </feature>
         </config-file>
-        <config-file target="AndroidManifest.xml" parent="/manifest" mode="merge">
+        <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.INTERNET"/>
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
             <uses-permission android:name="com.google.android.gms.permission.AD_ID" />


### PR DESCRIPTION
Fixes #213

This is the correct and working syntax from cordova plugin reference. Without it, the current syntax fails with cordova-commons 4.1.0 +.